### PR TITLE
Add install rule for the executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,7 @@ add_executable(groot2_formatter
     src/xml_formatter.cpp)
 
 target_link_libraries(groot2_formatter tinyxml_static)
+
+#---- install ----
+
+install(TARGETS groot2_formatter EXPORT groot2_formatterTargets)


### PR DESCRIPTION
Add a new cmake install rule to install the `groot2_formatter` executable. This is needed to run `make install`